### PR TITLE
Align depts -> jobs -> skills on change

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file, starting with 1.0.0beta.
 
+## \[1.0.8] - Unreleased
+
+- Fixed: Deselection of a department also unselects any tied jobs and skills that are no longer tied to a selected department. Same applies to deselection of a job with tied skills. (Thanks @ari-denary)
+
 ## \[1.0.7] - 2023-07-03
 
 - Fixed: Mobile Safari's floating bottom URL bar blocks sticky Search buttons.

--- a/src/components/SearchFilterSkills.tsx
+++ b/src/components/SearchFilterSkills.tsx
@@ -8,8 +8,13 @@ import CheckboxButton from './common/inputs/CheckboxButton';
 import { SearchContext } from '../context/SearchContext';
 
 export default function SearchFilterSkills() {
-	const { search, searchDispatch } = useContext(SearchContext);
-	const [data, { loading, error }] = useRelatedSkills(search.filters.positions.jobs);
+	const {
+		search: {
+			filters: { positions, skills },
+		},
+		searchDispatch,
+	} = useContext(SearchContext);
+	const [data, { loading, error }] = useRelatedSkills(positions.jobs);
 
 	const handleToggleTerm = (terms: string[]) => {
 		searchDispatch({
@@ -25,7 +30,7 @@ export default function SearchFilterSkills() {
 			<Heading as='h3' variant='searchFilterTitle'>
 				What skills are you looking for?
 			</Heading>
-			<CheckboxGroup defaultValue={search.filters.skills} onChange={handleToggleTerm}>
+			<CheckboxGroup defaultValue={skills} onChange={handleToggleTerm}>
 				<Wrap>
 					{data.map((term: WPItem) => (
 						<CheckboxButton key={term.id} value={term.id.toString()}>

--- a/src/hooks/queries/useLazyRelatedSkills.tsx
+++ b/src/hooks/queries/useLazyRelatedSkills.tsx
@@ -1,0 +1,21 @@
+/**
+ * useLazyRelatedSkills hook.
+ *
+ * Returns a function, that when called with an array of jobIds makes a query to get all related skills.
+ */
+
+import { LazyQueryExecFunction, QueryResult, useLazyQuery } from '@apollo/client';
+import { QUERY_RELATED_SKILLS } from './useRelatedSkills';
+
+/**
+ * useLazyRelatedSkills hook.
+ *
+ * Queries `skill` terms related to a job (`position` taxonomy)
+ *
+ * @returns {Array} The useLazyQuery return tuple.
+ */
+const useLazyRelatedSkills = (): [LazyQueryExecFunction<any, any>, QueryResult] => {
+	return useLazyQuery(QUERY_RELATED_SKILLS);
+};
+
+export default useLazyRelatedSkills;

--- a/src/hooks/queries/useRelatedSkills.tsx
+++ b/src/hooks/queries/useRelatedSkills.tsx
@@ -14,7 +14,7 @@ import { WPItemParams } from '../../lib/types';
 import { WPItem } from '../../lib/classes';
 import { sortWPItemsByName } from '../../lib/utils';
 
-const QUERY_RELATED_SKILLS = gql`
+export const QUERY_RELATED_SKILLS = gql`
 	query RelatedSkillsQuery($jobs: [ID!]) {
 		jobSkills(jobs: $jobs) {
 			id: databaseId

--- a/src/views/EditCreditView.tsx
+++ b/src/views/EditCreditView.tsx
@@ -15,7 +15,6 @@ import { sortWPItemsByName } from '../lib/utils';
 
 // TODO type this reducer
 function editCreditReducer(state: Credit, action: { type: string; payload: any }) {
-	console.log("editCreditReducer called with state = ", state, "action = ", action);
 
   switch (action.type) {
 		case 'UPDATE_INPUT':
@@ -66,7 +65,6 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
 	const { editProfile, editProfileDispatch } = useContext(EditProfileContext);
 	const credit = editProfile.credits?.find((credit) => credit.id === creditId);
 	const [editCredit, editCreditDispatch] = useReducer(editCreditReducer, credit);
-  console.log("editCreditView component loaded with editCredit = ", editCredit);
 
 	const {
 		updateCreditMutation,
@@ -88,10 +86,11 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
 	const [allDepartments] = usePositions();
 	const [getJobs, { data: allJobs, loading: jobsLoading }] = useLazyPositions();
 	const [jobs, setJobs] = useState<WPItem[]>([]);
-  const [getRelatedSkills, { data: allRelatedSkills, loading: relatedSkillsLoading}] = useLazyRelatedSkills();
+  const [
+    getRelatedSkills,
+    { data: allRelatedSkills, loading: relatedSkillsLoading}
+  ] = useLazyRelatedSkills();
   const [skills, setSkills] = useState<WPItem[]>([]);
-
-  console.log("EditCreditView rendered with jobs = ", jobs, " skills = ", skills)
 
   // fetch jobs & skills lists on mount
   useEffect(() => {
@@ -105,23 +104,22 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
    * @returns {Array} returns array of numbers of related/visible jobIds
    */
   const refetchAndSetJobs = async (departmentIds: number[]) => {
-    console.log("refetchAndSetJobs called with departmentIds = ", departmentIds);
-
     if (departmentIds.length === 0) {
       setJobs([]);
       return [];
     }
 
-    const jobData = await getJobs({ variables: { departments: departmentIds }, fetchPolicy: 'network-only' });
-    console.log("jobData in refetchJobs = ", jobData);
+    const jobData = await getJobs({
+      variables: { departments: departmentIds },
+      fetchPolicy: 'network-only'
+    });
     const jobsByDept = jobData?.data?.jobsByDepartments
 
     if (jobsByDept) {
       setJobs(jobsByDept.map((item: WPItem) => new WPItem(item)).sort(sortWPItemsByName));
       const jobsByDeptIds = jobsByDept.map((j: WPItem)=> Number(j.id));
       return jobsByDeptIds;
-    }
-    else {
+    } else {
       setJobs([]);
       return [];
     }
@@ -133,15 +131,15 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
  */
 
 const refetchAndSetSkills = async (jobIds: number[]) => {
-  console.log("refetchAndSetSkills called with jobIds = ", jobIds);
-
   if (jobIds.length === 0) {
     setSkills([]);
     return [];
   }
 
-  const skillData = await getRelatedSkills({ variables: { jobs: jobIds }, fetchPolicy: 'network-only' });
-  console.log("skillData in refetchSkills = ", skillData);
+  const skillData = await getRelatedSkills({
+    variables: { jobs: jobIds },
+    fetchPolicy: 'network-only'
+  });
   const relatedSkills = skillData?.data?.jobSkills
 
   if (relatedSkills) {
@@ -178,33 +176,39 @@ const refetchAndSetSkills = async (jobIds: number[]) => {
 	};
 
   const handleDepartmentsChange = (name: string) => async (terms: string[]) => {
-    console.log("handleDepartmentsChange called with name = ", name, "terms = ", terms)
     // update depts:
     const termsAsNums = terms.map((i)=> Number(i));
     dispatchCheckboxTermChange(name, termsAsNums);
+
     // update jobs to align with selected depts:
     const visibleJobs = await refetchAndSetJobs(termsAsNums);
-    const filteredSelectedJobIds = selectedJobIds.filter((id: number) => visibleJobs.includes(id));
-    dispatchCheckboxTermChange("jobs", filteredSelectedJobIds)
+    const filteredSelectedJobIds = selectedJobIds.filter(
+      (id: number) => visibleJobs.includes(id)
+    );
+    dispatchCheckboxTermChange("jobs", filteredSelectedJobIds);
+
     // update skills to align with selected jobs:
     const visibleSkills = await refetchAndSetSkills(filteredSelectedJobIds);
-    const filteredSelectedSkillIds = selectedSkills.filter((id: number) => visibleSkills.includes(id));
+    const filteredSelectedSkillIds = selectedSkills.filter(
+      (id: number) => visibleSkills.includes(id)
+    );
     dispatchCheckboxTermChange("skills", filteredSelectedSkillIds);
   }
 
   const handleJobsChange = (name: string) => async (terms: string[]) => {
-    console.log("handleJobsChange called with name = ", name, "terms = ", terms)
     // update jobs
     const termsAsNums = terms.map((i)=> Number(i));
     dispatchCheckboxTermChange(name, termsAsNums);
+
     // update skills to align with selected jobs:
     const visibleSkills = await refetchAndSetSkills(termsAsNums);
-    const filteredSelectedSkillIds = selectedSkills.filter((id: number) => visibleSkills.includes(id));
+    const filteredSelectedSkillIds = selectedSkills.filter(
+      (id: number) => visibleSkills.includes(id)
+    );
     dispatchCheckboxTermChange("skills", filteredSelectedSkillIds);
   }
 
   const handleSkillsChange = (name: string) => (terms: string[]) => {
-    console.log("handleSkillsChange called with name = ", name, "terms = ", terms)
     // update skills
     const termsAsNums = terms.map((i)=> Number(i));
     dispatchCheckboxTermChange(name, termsAsNums);

--- a/src/views/EditCreditView.tsx
+++ b/src/views/EditCreditView.tsx
@@ -85,10 +85,7 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
 	const [allDepartments] = usePositions();
 	const [getJobs, { loading: jobsLoading }] = useLazyPositions();
 	const [jobs, setJobs] = useState<WPItem[]>([]);
-  const [
-    getRelatedSkills,
-    { loading: relatedSkillsLoading}
-  ] = useLazyRelatedSkills();
+  const [getRelatedSkills, { loading: relatedSkillsLoading}] = useLazyRelatedSkills();
   const [skills, setSkills] = useState<WPItem[]>([]);
 
   // fetch jobs & skills lists on mount

--- a/src/views/EditCreditView.tsx
+++ b/src/views/EditCreditView.tsx
@@ -102,9 +102,9 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
 
   /** Fetches jobs given array of departmentIds, sets jobs
    *
-   * @returns {Array} returns array of related/visible jobIds TODO: say what type of data this array holds
+   * @returns {Array} returns array of numbers of related/visible jobIds
    */
-  const refetchAndSetJobs = async (departmentIds: string[]) => {
+  const refetchAndSetJobs = async (departmentIds: number[]) => {
     console.log("refetchAndSetJobs called with departmentIds = ", departmentIds);
 
     if (departmentIds.length === 0) {
@@ -118,7 +118,7 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
 
     if (jobsByDept) {
       setJobs(jobsByDept.map((item: WPItem) => new WPItem(item)).sort(sortWPItemsByName));
-      const jobsByDeptIds = jobsByDept.map((j: WPItem)=> j.id);
+      const jobsByDeptIds = jobsByDept.map((j: WPItem)=> Number(j.id));
       return jobsByDeptIds;
     }
     else {
@@ -129,7 +129,7 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
 
 /** Fetches skills given array of jobIds, sets skills
  *
- * @returns {Array} returns array of related/visible skillIds TODO: say what type of data this array holds
+ * @returns {Array} returns array of numbers related/visible skillIds
  */
 
 const refetchAndSetSkills = async (jobIds: number[]) => {
@@ -146,23 +146,24 @@ const refetchAndSetSkills = async (jobIds: number[]) => {
 
   if (relatedSkills) {
     setSkills(relatedSkills.map((item: WPItem) => new WPItem(item)).sort(sortWPItemsByName));
-    const relatedSkillIds = relatedSkills.map((s: WPItem)=> s.id);
-    return relatedSkillIds.map((id: number) => id.toString());
+    const relatedSkillIds = relatedSkills.map((s: WPItem)=> Number(s.id));
+    return relatedSkillIds;
   } else {
     setSkills([]);
     return [];
   }
 }
 
-const filterSelectedByVisible = (selectedIds: number[], visibleIds: string[]) => {
+/** Filter Selected Ids by Visibility */
+const filterSelectedByVisible = (selectedIds: number[], visibleIds: number[]) => {
   console.log("filterSelectedByVisibleJobs called with selectedIds =", selectedIds, "visibleIds = ", visibleIds);
   const filteredSelectedJobIds = selectedIds.filter((id: number) => {
-    let isIncluded = visibleIds.includes(String(id))
+    let isIncluded = visibleIds.includes(id);
     console.log("selected id = ", id, "is included in visibleIds = ", isIncluded);
     console.log("id type is ", typeof id);
     return isIncluded;
   });
-  return filteredSelectedJobIds.map((id) => id.toString());
+  return filteredSelectedJobIds;
 }
 
 	const handleInputChange = (
@@ -179,7 +180,7 @@ const filterSelectedByVisible = (selectedIds: number[], visibleIds: string[]) =>
 		});
 	};
 
-	const dispatchCheckboxTermChange = (name: string, terms: string[]) => {
+	const dispatchCheckboxTermChange = (name: string, terms: number[]) => {
 		editCreditDispatch({
 			type: `UPDATE_${name.toUpperCase()}`,
 			payload: {
@@ -191,13 +192,14 @@ const filterSelectedByVisible = (selectedIds: number[], visibleIds: string[]) =>
   const handleDepartmentsChange = (name: string) => async (terms: string[]) => {
     console.log("handleDepartmentsChange called with name = ", name, "terms = ", terms)
     // update depts:
-    dispatchCheckboxTermChange(name, terms);
+    const termsAsNums = terms.map((i)=> Number(i));
+    dispatchCheckboxTermChange(name, termsAsNums);
     // update jobs to align with selected depts:
-    const visibleJobs = await refetchAndSetJobs(terms);
+    const visibleJobs = await refetchAndSetJobs(termsAsNums);
     const filteredSelectedJobIds = filterSelectedByVisible(selectedJobIds, visibleJobs);
     dispatchCheckboxTermChange("jobs", filteredSelectedJobIds)
     // update skills to align with selected jobs:
-    const visibleSkills = await refetchAndSetSkills(filteredSelectedJobIds.map((id)=> Number(id)));
+    const visibleSkills = await refetchAndSetSkills(filteredSelectedJobIds);
     const filteredSelectedSkillIds = filterSelectedByVisible(selectedSkills, visibleSkills)
     dispatchCheckboxTermChange("skills", filteredSelectedSkillIds);
   }
@@ -205,9 +207,10 @@ const filterSelectedByVisible = (selectedIds: number[], visibleIds: string[]) =>
   const handleJobsChange = (name: string) => async (terms: string[]) => {
     console.log("handleJobsChange called with name = ", name, "terms = ", terms)
     // update jobs
-    dispatchCheckboxTermChange(name, terms);
+    const termsAsNums = terms.map((i)=> Number(i));
+    dispatchCheckboxTermChange(name, termsAsNums);
     // update skills to align with selected jobs:
-    const visibleSkills = await refetchAndSetSkills(terms.map((id)=> Number(id)));
+    const visibleSkills = await refetchAndSetSkills(termsAsNums);
     const filteredSelectedSkillIds = filterSelectedByVisible(selectedSkills, visibleSkills)
     dispatchCheckboxTermChange("skills", filteredSelectedSkillIds);
   }
@@ -215,7 +218,8 @@ const filterSelectedByVisible = (selectedIds: number[], visibleIds: string[]) =>
   const handleSkillsChange = (name: string) => (terms: string[]) => {
     console.log("handleSkillsChange called with name = ", name, "terms = ", terms)
     // update skills
-    dispatchCheckboxTermChange(name, terms);
+    const termsAsNums = terms.map((i)=> Number(i));
+    dispatchCheckboxTermChange(name, termsAsNums);
   }
 
 	const handleRadioInputChange = (name: string) => (value: string) => {

--- a/src/views/EditCreditView.tsx
+++ b/src/views/EditCreditView.tsx
@@ -112,9 +112,9 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
       return [];
     }
 
-    const result = await getJobs({ variables: { departments: departmentIds }, fetchPolicy: 'network-only' });
-    console.log("result in refetchJobs = ", result);
-    const jobsByDept = result?.data?.jobsByDepartments
+    const jobData = await getJobs({ variables: { departments: departmentIds }, fetchPolicy: 'network-only' });
+    console.log("jobData in refetchJobs = ", jobData);
+    const jobsByDept = jobData?.data?.jobsByDepartments
 
     if (jobsByDept) {
       setJobs(jobsByDept.map((item: WPItem) => new WPItem(item)).sort(sortWPItemsByName));
@@ -140,9 +140,9 @@ const refetchAndSetSkills = async (jobIds: number[]) => {
     return [];
   }
 
-  const result = await getRelatedSkills({ variables: { jobs: jobIds }, fetchPolicy: 'network-only' });
-  console.log("result in refetchSkills = ", result);
-  const relatedSkills = result?.data?.jobSkills
+  const skillData = await getRelatedSkills({ variables: { jobs: jobIds }, fetchPolicy: 'network-only' });
+  console.log("skillData in refetchSkills = ", skillData);
+  const relatedSkills = skillData?.data?.jobSkills
 
   if (relatedSkills) {
     setSkills(relatedSkills.map((item: WPItem) => new WPItem(item)).sort(sortWPItemsByName));
@@ -152,18 +152,6 @@ const refetchAndSetSkills = async (jobIds: number[]) => {
     setSkills([]);
     return [];
   }
-}
-
-/** Filter Selected Ids by Visibility */
-const filterSelectedByVisible = (selectedIds: number[], visibleIds: number[]) => {
-  console.log("filterSelectedByVisibleJobs called with selectedIds =", selectedIds, "visibleIds = ", visibleIds);
-  const filteredSelectedJobIds = selectedIds.filter((id: number) => {
-    let isIncluded = visibleIds.includes(id);
-    console.log("selected id = ", id, "is included in visibleIds = ", isIncluded);
-    console.log("id type is ", typeof id);
-    return isIncluded;
-  });
-  return filteredSelectedJobIds;
 }
 
 	const handleInputChange = (
@@ -196,11 +184,11 @@ const filterSelectedByVisible = (selectedIds: number[], visibleIds: number[]) =>
     dispatchCheckboxTermChange(name, termsAsNums);
     // update jobs to align with selected depts:
     const visibleJobs = await refetchAndSetJobs(termsAsNums);
-    const filteredSelectedJobIds = filterSelectedByVisible(selectedJobIds, visibleJobs);
+    const filteredSelectedJobIds = selectedJobIds.filter((id: number) => visibleJobs.includes(id));
     dispatchCheckboxTermChange("jobs", filteredSelectedJobIds)
     // update skills to align with selected jobs:
     const visibleSkills = await refetchAndSetSkills(filteredSelectedJobIds);
-    const filteredSelectedSkillIds = filterSelectedByVisible(selectedSkills, visibleSkills)
+    const filteredSelectedSkillIds = selectedSkills.filter((id: number) => visibleSkills.includes(id));
     dispatchCheckboxTermChange("skills", filteredSelectedSkillIds);
   }
 
@@ -211,7 +199,7 @@ const filterSelectedByVisible = (selectedIds: number[], visibleIds: number[]) =>
     dispatchCheckboxTermChange(name, termsAsNums);
     // update skills to align with selected jobs:
     const visibleSkills = await refetchAndSetSkills(termsAsNums);
-    const filteredSelectedSkillIds = filterSelectedByVisible(selectedSkills, visibleSkills)
+    const filteredSelectedSkillIds = selectedSkills.filter((id: number) => visibleSkills.includes(id));
     dispatchCheckboxTermChange("skills", filteredSelectedSkillIds);
   }
 

--- a/src/views/EditCreditView.tsx
+++ b/src/views/EditCreditView.tsx
@@ -3,7 +3,6 @@ import { Divider, Flex, Heading, Text, Spinner, Stack, StackItem } from '@chakra
 import { Credit, WPItem } from '../lib/classes';
 import { EditProfileContext } from '../context/EditProfileContext';
 import usePositions from '../hooks/queries/usePositions';
-import useRelatedSkills from '../hooks/queries/useRelatedSkills';
 import useLazyPositions from '../hooks/queries/useLazyPositions';
 import useLazyRelatedSkills from '../hooks/queries/useLazyRelatedSkills';
 import useUpdateCredit from '../hooks/mutations/useUpdateCredit';
@@ -84,11 +83,11 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
 	} = editCredit;
 
 	const [allDepartments] = usePositions();
-	const [getJobs, { data: allJobs, loading: jobsLoading }] = useLazyPositions();
+	const [getJobs, { loading: jobsLoading }] = useLazyPositions();
 	const [jobs, setJobs] = useState<WPItem[]>([]);
   const [
     getRelatedSkills,
-    { data: allRelatedSkills, loading: relatedSkillsLoading}
+    { loading: relatedSkillsLoading}
   ] = useLazyRelatedSkills();
   const [skills, setSkills] = useState<WPItem[]>([]);
 
@@ -363,7 +362,11 @@ const refetchAndSetSkills = async (jobIds: number[]) => {
 							<ProfileCheckboxGroup
 								name='jobs'
 								items={jobs}
-								checked={selectedJobIds?.map((item: number) => item.toString())}
+								checked={
+                  selectedJobIds
+                  ? selectedJobIds.map((item: number) => item.toString())
+                  : []
+                }
 								handleChange={handleJobsChange}
 							/>
 						</>
@@ -382,7 +385,11 @@ const refetchAndSetSkills = async (jobIds: number[]) => {
 							<ProfileCheckboxGroup
 								name='skills'
 								items={skills}
-								checked={selectedSkills?.map((item: number) => item.toString())}
+								checked={
+                  selectedSkills
+                  ? selectedSkills.map((item: number) => item.toString())
+                  : []
+                }
 								handleChange={handleSkillsChange}
 							/>
 						</>


### PR DESCRIPTION
Deselection of a department also unselects any tied jobs and skills that are no longer tied to a selected department. Same applies to deselection of a job with tied skills.
Fixes #79 
![rise-bug-credits-fix](https://github.com/roundhousedesigns/rise-frontend/assets/77554154/1e867799-4a83-4d75-866d-837709863c02)


While working on this, it was also discovered that the data type held within selected skills, jobs, and departments changes from an array of numbers to an array of strings upon user input. 

Problem shown here:
![rise-data-type-diff](https://github.com/roundhousedesigns/rise-frontend/assets/77554154/04c6d21a-a0b9-4bbc-83fe-6e7c3542827b)


Fixed result maintains number array data type:
![rise-data-diff-fix](https://github.com/roundhousedesigns/rise-frontend/assets/77554154/5abd52ce-54ad-4c87-808d-883981ea63b2)
