### PR TITLE
Hotfix/update credit positions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file, starting wi
 - Feature: Dashboard updates/notices feed
 - Feature: Basic password complexity enforcement
 - Fixed: Deselection of a department also unselects any tied jobs and skills that are no longer tied to a selected department. Same applies to deselection of a job with tied skills. (Thanks @ari-denary)
-- Improved: Added common `ConfirmActionDialog`` component for confirmation dialogs
+- Improved: Added common `ConfirmActionDialog` component for confirmation dialogs
 - Improved: Profile Share icon moved into Card component.
 - Improved: Menu icon standout color
 - Improved: Styling and layout

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,9 @@
 
 All notable changes to this project will be documented in this file, starting with 1.0.0beta.
 
-## \[1.0.9] - Unreleased
+## \[1.0.8-hotfix1] - 2023-08-17
 
-- Fixed: Additional Filter state not resetting visually after clicking "Reset"
-- Fixed: Search submit button bar bg color
+- Fixed/Improved: Credits not updating. Fix involved more overt use of departments and jobs, instead of relying on the `position` term. Concurrent backend fix to match.
 
 ## \[1.0.8] - 2023-08-09
 

--- a/src/components/CreditItem.tsx
+++ b/src/components/CreditItem.tsx
@@ -31,7 +31,7 @@ export default function CreditItem({ credit, isEditable, onClick, ...props }: Pr
 		title,
 		jobTitle,
 		jobLocation,
-		positions: { department: departmentIds, jobs: jobIds } = { department: [], jobs: [] },
+		positions: { departments: departmentIds, jobs: jobIds } = { departments: [], jobs: [] },
 		skills: skillIds,
 		venue,
 		workStart,
@@ -44,7 +44,7 @@ export default function CreditItem({ credit, isEditable, onClick, ...props }: Pr
 	const memoizedTermList = useMemo(() => termList, [termList]);
 
 	// FIXME When departmentIds doesn't exist or is empty, the hook returns the first page of all terms.
-	const [department] = useTaxonomyTerms(departmentIds ? departmentIds : []);
+	const [departments] = useTaxonomyTerms(departmentIds ? departmentIds : []);
 
 	// The term items for each set.
 	const [jobs, setJobs] = useState<WPItem[]>([]);
@@ -166,7 +166,7 @@ export default function CreditItem({ credit, isEditable, onClick, ...props }: Pr
 								{departmentIds?.length || jobs?.length || skills?.length ? (
 									<>
 										<Wrap spacing={2} justify={{ base: 'left', md: 'right' }}>
-											{department?.map((department: WPItem) => (
+											{departments?.map((department: WPItem) => (
 												<Tag key={department.id} colorScheme='orange'>
 													<TagLabel>{decodeString(department.name)}</TagLabel>
 												</Tag>

--- a/src/hooks/mutations/useUpdateCredit.tsx
+++ b/src/hooks/mutations/useUpdateCredit.tsx
@@ -21,7 +21,7 @@ const MUTATE_UPDATE_CREDIT = gql`
 				workStart
 				workEnd
 				workCurrent
-				department
+				departments
 				jobs
 				skills
 			}
@@ -33,6 +33,7 @@ const useUpdateCredit = () => {
 	const [mutation, results] = useMutation(MUTATE_UPDATE_CREDIT);
 
 	const updateCreditMutation = (credit: CreditOutput, userId: number) => {
+		console.info(credit);
 		return mutation({
 			variables: {
 				input: {

--- a/src/hooks/queries/useUserProfile.tsx
+++ b/src/hooks/queries/useUserProfile.tsx
@@ -107,7 +107,14 @@ const useUserProfile = (id: number): [UserProfile | null, any] => {
 		// If credit at least has an id and a title, return a new Credit object
 		if (!credit.id || !credit.title) return null;
 
-		return new Credit({
+		const departments = credit.positions?.nodes.filter(
+			(position: { __typename: string; id: number; parentId: number }) => position.parentId === null
+		);
+		const jobs = credit.positions?.nodes.filter(
+			(position: { __typename: string; id: number; parentId: number }) => position.parentId !== null
+		);
+
+		const newCredit = new Credit({
 			id: credit.id,
 			index: credit.index,
 			title: credit.title,
@@ -118,10 +125,12 @@ const useUserProfile = (id: number): [UserProfile | null, any] => {
 			workStart: credit.workStart,
 			workEnd: credit.workEnd,
 			workCurrent: credit.workCurrent,
-			department: credit.positions?.nodes.map((job: WPItem) => job.parentId),
-			jobs: credit.positions?.nodes.map((job: WPItem) => job.id),
+			departments: departments?.map((department: WPItem) => department.id),
+			jobs: jobs?.map((job: WPItem) => job.id),
 			skills: credit.skills?.nodes.map((skill: WPItem) => skill.id),
 		});
+
+		return newCredit;
 	});
 
 	// Reorder the credits

--- a/src/lib/classes.ts
+++ b/src/lib/classes.ts
@@ -288,9 +288,9 @@ export class Credit implements CreditParams {
 	workEnd: string;
 	workCurrent: boolean;
 	positions: {
-		department: number[];
+		departments: number[];
 		jobs: number[];
-	} = { department: [], jobs: [] };
+	} = { departments: [], jobs: [] };
 	skills: number[];
 	isNew: boolean = false;
 
@@ -306,28 +306,28 @@ export class Credit implements CreditParams {
 		this.workEnd = params.workEnd ? params.workEnd : '';
 		this.workCurrent = params.workCurrent || false;
 		this.skills = params.skills ? params.skills : [];
-		this.positions = this.getPositions(params) || { department: [], jobs: [] };
+		this.positions = this.getPositions(params) || { departments: [], jobs: [] };
 		this.isNew = Boolean(params.isNew) || false;
 	}
 
 	/**
 	 * Get the positions of the credit.
 	 * @param {CreditParams} params - Credit parameters
-	 * @returns {Object} An object containing department and jobs
+	 * @returns {Object} An object containing departments and jobs
 	 */
-	private getPositions(params: CreditParams): { department: number[]; jobs: number[] } {
+	private getPositions(params: CreditParams): { departments: number[]; jobs: number[] } {
 		if (params.positions) {
 			return params.positions;
 		}
 
 		if (
-			params.department &&
-			params.department.length > 0 &&
+			params.departments &&
+			params.departments.length > 0 &&
 			params.jobs &&
 			params.jobs.length > 0
 		) {
 			return {
-				department: params.department.map((department) => Number(department)),
+				departments: params.departments.map((departments) => Number(departments)),
 				jobs: params.jobs.map((job) => Number(job)),
 			};
 		}
@@ -340,10 +340,13 @@ export class Credit implements CreditParams {
 	 * @returns {CreditOutput} A sanitized credit object.
 	 */
 	prepareCreditForGraphQL(): CreditOutput {
+		const { positions, ...rest } = this;
+
 		return {
-			...this,
+			...rest,
 			id: Number(this.id),
-			positions: this.positions.jobs,
+			departments: positions.departments,
+			jobs: positions.jobs,
 		};
 	}
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -99,7 +99,7 @@ export interface PersonalLinksParams {
  * The data shape for Credit input.
  */
 export interface CreditParams {
-	id: string | number; // Using a string here because we sometimes need to generate a unique ID for a new credit, and alphanumeric is better.
+	id: string | number; // Allowing a string here because we sometimes need to generate a unique ID for a new credit, and alphanumeric is better.
 	index: number;
 	title?: string;
 	jobTitle?: string;
@@ -109,10 +109,10 @@ export interface CreditParams {
 	workStart?: string;
 	workEnd?: string;
 	workCurrent?: boolean;
-	department?: number[];
+	departments?: number[];
 	jobs?: number[];
 	positions?: {
-		department: number[];
+		departments: number[];
 		jobs: number[];
 	};
 	skills?: number[];
@@ -133,7 +133,8 @@ export interface CreditOutput {
 	workStart: string;
 	workEnd: string;
 	workCurrent: boolean;
-	positions: number[];
+	departments: number[];
+	jobs: number[];
 	skills: number[];
 	isNew: boolean;
 }
@@ -186,7 +187,7 @@ export interface updateBookmarkedProfilesInput {
  */
 export interface SearchParams {
 	positions: {
-		department?: string[];
+		departments?: string[];
 		jobs?: string[];
 		skills?: string[];
 	};

--- a/src/views/EditCreditView.tsx
+++ b/src/views/EditCreditView.tsx
@@ -21,12 +21,12 @@ function editCreditReducer(state: Credit, action: { type: string; payload: any }
 				[action.payload.name]: action.payload.value,
 			};
 
-		case 'UPDATE_DEPARTMENT':
+		case 'UPDATE_DEPARTMENTS':
 			return {
 				...state,
 				positions: {
 					...state.positions,
-					department: action.payload.value.map((item: number) => item),
+					departments: action.payload.value.map((item: number) => item),
 				},
 			};
 
@@ -77,7 +77,7 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
 		workStart,
 		workEnd,
 		workCurrent,
-		positions: { department: selectedDepartmentIds = [], jobs: selectedJobIds = [] },
+		positions: { departments: selectedDepartmentIds = [], jobs: selectedJobIds = [] },
 		skills: selectedSkills,
 	} = editCredit;
 
@@ -341,7 +341,7 @@ export default function EditCreditView({ creditId, onClose: closeModal }: Props)
 					</Heading>
 					<Text>Select all department(s) you worked under.</Text>
 					<ProfileCheckboxGroup
-						name='department'
+						name='departments'
 						items={allDepartments}
 						checked={
 							selectedDepartmentIds

--- a/src/views/ProfileView.tsx
+++ b/src/views/ProfileView.tsx
@@ -11,7 +11,7 @@ import {
 	Card,
 	Avatar,
 	Tag,
-	UnorderedList,
+	List,
 	ListItem,
 	StackItem,
 	Link,
@@ -126,11 +126,11 @@ export default function ProfileView({ profile, allowBookmark = true }: Props): J
 		const items = getWPItemsFromIds(ids, terms);
 
 		return items ? (
-			<Wrap>
+			<Flex gap={1}>
 				{items.map((item: WPItem) => (
 					<Tag key={item.id}>{item.name}</Tag>
 				))}
-			</Wrap>
+			</Flex>
 		) : null;
 	};
 
@@ -273,7 +273,7 @@ export default function ProfileView({ profile, allowBookmark = true }: Props): J
 									{locationTerms ? SelectedTerms({ ids: locations, terms: locationTerms }) : false}
 								</TextWithIcon>
 								<TextWithIcon icon={FiMap} mr={2}>
-									<Wrap>
+									<Flex gap={1}>
 										{willTravel !== undefined && (
 											<Tag size='md' colorScheme={willTravel ? 'green' : 'orange'}>
 												{willTravel ? 'Will Travel' : 'Local Only'}
@@ -284,7 +284,7 @@ export default function ProfileView({ profile, allowBookmark = true }: Props): J
 												{willTour ? 'Will Tour' : 'No Tours'}
 											</Tag>
 										)}
-									</Wrap>
+									</Flex>
 								</TextWithIcon>
 							</StackItem>
 						) : (
@@ -327,7 +327,7 @@ export default function ProfileView({ profile, allowBookmark = true }: Props): J
 							<Heading as='h3' variant='contentTitle'>
 								Contact
 							</Heading>
-							<UnorderedList listStyleType='none' m={0} spacing={1}>
+							<List m={0} spacing={1}>
 								{email ? (
 									<ListItem>
 										<LinkWithIcon href={`mailto:${email}`} icon={FiMail}>
@@ -355,7 +355,7 @@ export default function ProfileView({ profile, allowBookmark = true }: Props): J
 								) : (
 									false
 								)}
-							</UnorderedList>
+							</List>
 						</StackItem>
 
 						<StackItem>
@@ -399,13 +399,13 @@ export default function ProfileView({ profile, allowBookmark = true }: Props): J
 					<Flex justifyContent='flex-end'>
 						<CreditsTagLegend mr={4} />
 					</Flex>
-					<UnorderedList listStyleType='none' m={0}>
+					<List m={0}>
 						{creditsSorted.map((credit: Credit) => (
 							<ListItem key={credit.id}>
 								<CreditItem credit={credit} />
 							</ListItem>
 						))}
-					</UnorderedList>
+					</List>
 				</StackItem>
 			)}
 


### PR DESCRIPTION
Fix credits not updating. Part of this fix is making clearer use of 'departments' and 'jobs' rather than relying as heavily on the flattened 'positions' terms.

Part of this fix required a backend update, as well. https://github.com/roundhousedesigns/rise-backend/commit/ddbc7face39359a5370b542c3c46ffee79afa6ef