### PR TITLE
Fix: results not loading on first attempt

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,8 +3,11 @@
 All notable changes to this project will be documented in this file, starting
 with 1.0.0beta.
 
-## \[1.1.9] - 2024-07-20
+## \[1.1.91]
 
+## \[1.1.9 - 1.1.91] - 2024-07-20
+
+- Fix: Search results sometimes not loading on first attempt.
 - Add: "Multilingual" local checkbox with simple "languages spoken" field.
 - Add: `<DevMode>` component for dev branch display.
 - Add: Import version from package.json.

--- a/src/hooks/queries/useCandidateSearch.tsx
+++ b/src/hooks/queries/useCandidateSearch.tsx
@@ -46,9 +46,7 @@ const QUERY_CANDIDATES = gql`
  * @returns {Array} The useLazyQuery return tuple.
  */
 const useCandidateSearch = (): [LazyQueryExecFunction<any, any>, QueryResult] => {
-	return useLazyQuery(QUERY_CANDIDATES, {
-		fetchPolicy: 'no-cache',
-	});
+	return useLazyQuery(QUERY_CANDIDATES);
 };
 
 export default useCandidateSearch;

--- a/src/hooks/queries/useUserProfile.tsx
+++ b/src/hooks/queries/useUserProfile.tsx
@@ -110,7 +110,6 @@ const useUserProfile = (id: number | null, count?: number): [UserProfile | null,
 			last: count,
 		},
 		skip: id === null,
-		fetchPolicy: 'cache-and-network',
 	});
 
 	// Prepare the credits

--- a/src/views/SearchResultsView.tsx
+++ b/src/views/SearchResultsView.tsx
@@ -55,13 +55,19 @@ export default function SearchResultsView() {
 	const orderedResults: number[] = useMemo(() => {
 		if (!resultsCount) return [];
 
+		// Don't mess with state.
+		const resultsForSort = [...results];
+
 		// Sort the results by score.
-		const sortedResults = results.sort((a, b) => {
-			return b.score - a.score;
+		const sortedResults = resultsForSort.sort((a, b) => {
+			const { score: aScore } = a;
+			const { score: bScore } = b;
+
+			return aScore - bScore;
 		});
 
 		return sortedResults.map((item) => Number(item.id));
-	}, [results]);
+	}, [resultsCount, results]);
 
 	const ConflictDateLegend = () => {
 		return jobDates && jobDates.startDate ? (

--- a/src/views/SearchWizardView.tsx
+++ b/src/views/SearchWizardView.tsx
@@ -142,13 +142,13 @@ export default function SearchWizardView({ onSubmit }: Props) {
 				<SearchFilterAccordionItem
 					heading={
 						<Flex alignItems='center'>
-							<Icon as={FiFolder} fill={savedSearches.length > 0 ? orange : 'transparent'} mr={2} />
+							<Icon as={FiFolder} fill={savedSearches?.length > 0 ? orange : 'transparent'} mr={2} />
 							<Text as='span' my={0}>
 								Saved Searches
 							</Text>
 						</Flex>
 					}
-					isDisabled={!savedSearches.length}
+					isDisabled={!savedSearches || !savedSearches.length}
 					headingProps={{ fontSize: 'md' }}
 					panelProps={{ mb: 0, px: 3, pb: 4 }}
 				>


### PR DESCRIPTION
Fix: search results sometimes don't load on first attempt due to accidental altering of context `results` variable during sort operation.